### PR TITLE
Clean up c code, fix (some) thread-safety bugs

### DIFF
--- a/cbits/p5embed.c
+++ b/cbits/p5embed.c
@@ -225,9 +225,10 @@ XS(__HsPerl5__Invoke) {
 
     dXSARGS;
 
-    if (items < 1) {
-      hate;
-    }
+    // TODO: report error in some other way
+    //if (items < 1) {
+    //  hate;
+    //}
 
     sv = ST(0);
 

--- a/cbits/p5embed.c
+++ b/cbits/p5embed.c
@@ -2,7 +2,7 @@
 #define HsPerl5DefinedC 1
 
 #include "p5embed.h"
-#include <XSUB.h>
+//#include <XSUB.h>
 #include "perlxsi.h"
 
 /* define to enable pugsembed debug messages */

--- a/cbits/p5embed.c
+++ b/cbits/p5embed.c
@@ -22,9 +22,6 @@ const char HsPerl5Preamble[] =
 
 static PerlInterpreter *my_perl;
 
-// probably left over from earlier code
-int _P5EMBED_INIT = 0;
-
 SV *
 perl5_sv_undef ()
 {
@@ -44,7 +41,7 @@ perl5_sv_no ()
 }
 
 // mark as not Unicode-safe
-// if callers want Utf8, they should apply it themselves
+// if callers want Utf8, they should apply SvUTF8_on themselves
 SV **
 perl5_eval(char *code, int len, int cxt)
 {
@@ -116,7 +113,7 @@ perl5_SvPV ( SV *sv )
 }
 
 // mark as not Unicode safe - if calls
-// want Utf8, they should apply it themselves
+// want Utf8, they should apply SvUTF8_on themselves
 SV *
 perl5_newSVpvn ( char * pv, int len )
 {

--- a/hs-perl5.cabal
+++ b/hs-perl5.cabal
@@ -90,7 +90,12 @@ test-suite hs-perl5-test
                      , text
                      , interpolatedstring-perl6
                      , temporary
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:
+    -- ideally, should compile & run tests
+    -- both with and without threading.
+                       -rtsopts
+                       -threaded
+                       -with-rtsopts=-N
                        -Wall -fwarn-tabs
   default-language:    Haskell2010
 

--- a/src/Language/Perl5/Internal.hs
+++ b/src/Language/Perl5/Internal.hs
@@ -84,6 +84,10 @@ foreign import ccall "perl5_sv_yes"
 
 foreign import ccall "perl5_sv_no"
     perl5_sv_no :: IO SV
+
+-- | warning: only handles non-null ASCII strings - not Unicode-safe.
+--
+-- caller should free returned memory.
 foreign import ccall "perl5_eval"
     perl5_eval :: CString -> CInt -> CInt -> IO (Ptr SV)
 
@@ -94,6 +98,8 @@ foreign import ccall "perl5_eval"
 -- len bytes long. If the s argument is NULL the new SV will be undefined.
 --
 -- See <https://perldoc.perl.org/perlapi#newSVpvn>
+--
+-- warning: only handles non-null ASCII strings - not Unicode-safe.
 foreign import ccall "perl5_newSVpvn"
     perl5_newSVpvn :: CString -> CInt -> IO SV
 
@@ -181,6 +187,8 @@ foreign import ccall "perl_free"
 --
 -- Return values are given according to the same protocol as
 -- 'perl5_eval'.
+--
+-- Caller should free returned memory.
 foreign import ccall "perl5_apply"
     perl5_apply :: SV -> SV -> Ptr SV -> CInt -> IO (Ptr SV)
 
@@ -208,5 +216,12 @@ foreign import ccall "perl5_get_sv"
 -- See <https://perldoc.perl.org/perlapi#get_cv>
 foreign import ccall "perl5_get_cv"
     perl5_get_cv :: CString -> IO SV
+
+-- | If it's desired Perl be extra-hygienic about cleaning up resources,
+-- this should be called (a) after allocation, but before initialization, and (b) before
+-- destruction. Currently, our initialization code already includes a call to it.
+-- (Multiple calls are harmless, though.)
+foreign import ccall "perl5_set_destruct_level"
+    perl5_set_destruct_level :: IO ()
 
 

--- a/src/Language/Perl5/Internal/Types.hs
+++ b/src/Language/Perl5/Internal/Types.hs
@@ -37,7 +37,10 @@ import Language.Perl5.Internal.Constants
 newtype Interpreter = Interpreter { unInterpreter :: Ptr Interpreter } deriving (Show, Eq)
 -- | (pointer to a) scalar value.
 newtype SV          = SV          { unSV          :: Ptr SV }          deriving (Show, Eq)
-
+-- | (pointer to an) array value.
+newtype AV          = AV          { unAV          :: Ptr AV }          deriving (Show, Eq)
+-- | (pointer to a) code value.
+newtype CV          = CV          { unCV          :: Ptr CV }          deriving (Show, Eq)
 
 -- | type of a callback from Perl into Haskell.
 type Callback = Ptr SV -> CInt -> IO (Ptr SV)

--- a/src/Language/Perl5/Internal/Types.hs
+++ b/src/Language/Perl5/Internal/Types.hs
@@ -38,6 +38,10 @@ newtype Interpreter = Interpreter { unInterpreter :: Ptr Interpreter } deriving 
 -- | (pointer to a) scalar value.
 newtype SV          = SV          { unSV          :: Ptr SV }          deriving (Show, Eq)
 -- | (pointer to an) array value.
+
+-----
+-- for use later:
+
 newtype AV          = AV          { unAV          :: Ptr AV }          deriving (Show, Eq)
 -- | (pointer to a) code value.
 newtype CV          = CV          { unCV          :: Ptr CV }          deriving (Show, Eq)

--- a/src/Language/Perl5/Types.hs
+++ b/src/Language/Perl5/Types.hs
@@ -8,7 +8,7 @@ Types for interfacing with an embedded Perl interpreter.
 
 module Language.Perl5.Types
   (
-  -- * Basic tyoes
+  -- * Basic types
     SV
   , Interpreter
   , Callback


### PR DESCRIPTION
Removes superfluous C code.

Fixes #8.
(By ensuring access to the interpreter is always from a single, OS-bound thread.)